### PR TITLE
CMake: 2nd try

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,11 @@ Release*
 *.*sdf
 *.VC.db
 *.VC.opendb
+*.vs/*
 ipch/
 CMakeCache.txt
 CMakeFiles/
+CMakeSettings.json
 *.cmake
 !Modules/*.cmake
 

--- a/Modules/ConfigureWindows.cmake
+++ b/Modules/ConfigureWindows.cmake
@@ -1,0 +1,44 @@
+if(WIN32)
+	option(SHARED_RUNTIME "Windows: Build using the shared runtime library (/MD), disable for static runtime (/MT)" ON)
+
+	# Set compiler options.
+	set(variables
+		CMAKE_C_FLAGS_DEBUG
+		CMAKE_C_FLAGS_MINSIZEREL
+		CMAKE_C_FLAGS_RELEASE
+		CMAKE_C_FLAGS_RELWITHDEBINFO
+		CMAKE_CXX_FLAGS_DEBUG
+		CMAKE_CXX_FLAGS_MINSIZEREL
+		CMAKE_CXX_FLAGS_RELEASE
+		CMAKE_CXX_FLAGS_RELWITHDEBINFO
+	)
+	if(SHARED_RUNTIME)
+		message(STATUS "Windows: Using dynamic runtime library (/MD)")
+		foreach(variable ${variables})
+			if(${variable} MATCHES "/MT")
+				string(REGEX REPLACE "/MT" "/MD" ${variable} "${${variable}}")
+			endif()
+		endforeach()
+	else()
+		message(STATUS "Windows: Using static runtime library (/MT)")
+		foreach(variable ${variables})
+			if(${variable} MATCHES "/MD")
+				string(REGEX REPLACE "/MD" "/MT" ${variable} "${${variable}}")
+			endif()
+		endforeach()
+	endif()
+
+	# Target Unicode API
+	add_definitions(-D_UNICODE)
+	add_definitions(-DUNICODE)
+
+	# Disable API deprecation warnings
+	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif()
+
+if(MSVC)
+	option(MSVC_MULTICORE "MSVC: Build using multiple cores (/MP)" ON)
+	if (MSVC_MULTICORE)
+		add_compile_options(/MP)
+	endif()
+endif()

--- a/Modules/FindSDL2.cmake
+++ b/Modules/FindSDL2.cmake
@@ -240,6 +240,20 @@ if(SDL2_FOUND)
 		if(WIN32)
 			set_property(TARGET SDL2::SDL2 APPEND_STRING PROPERTY
 				INTERFACE_LINK_LIBRARIES "winmm;imm32;version")
+		elseif(APPLE)
+			find_library(COREVIDEO CoreVideo)
+			find_library(COCOA_LIBRARY Cocoa)
+			find_library(IOKIT IOKit)
+			find_library(FORCEFEEDBACK ForceFeedback)
+			find_library(CARBON_LIBRARY Carbon)
+			find_library(COREAUDIO CoreAudio)
+			find_library(AUDIOTOOLBOX AudioToolbox)
+			find_library(ICONV_LIBRARY iconv)
+			set_property(TARGET SDL2::SDL2 APPEND_STRING PROPERTY
+				INTERFACE_LINK_LIBRARIES ${COREVIDEO} ${COCOA_LIBRARY}
+					${IOKIT} ${FORCEFEEDBACK} ${CARBON_LIBRARY}
+					${COREAUDIO} ${AUDIOTOOLBOX} ${ICONV_LIBRARY}
+			)
 		endif()
 	endif()
 	mark_as_advanced(SDL2_ROOT_DIR)

--- a/Modules/FindSDL2.cmake
+++ b/Modules/FindSDL2.cmake
@@ -1,173 +1,254 @@
+# - Find SDL2
+# Find the SDL2 headers and libraries
+#
+#  SDL2::SDL2 - Imported target to use for building a library
+#  SDL2::SDL2main - Imported interface target to use if you want SDL and SDLmain.
+#  SDL2_FOUND - True if SDL2 was found.
+#  SDL2_DYNAMIC - If we found a DLL version of SDL (meaning you might want to copy a DLL from SDL2::SDL2)
+#
+# Original Author:
+# 2015 Ryan Pavlik <ryan.pavlik@gmail.com> <abiryan@ryand.net>
+#
+# Copyright Sensics, Inc. 2015.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
 
-# This module defines
-# SDL2_LIBRARY, the name of the library to link against
-# SDL2_FOUND, if false, do not try to link to SDL2
-# SDL2_INCLUDE_DIR, where to find SDL.h
-#
-# This module responds to the the flag:
-# SDL2_BUILDING_LIBRARY
-# If this is defined, then no SDL2main will be linked in because
-# only applications need main().
-# Otherwise, it is assumed you are building an application and this
-# module will attempt to locate and set the the proper link flags
-# as part of the returned SDL2_LIBRARY variable.
-#
-# Don't forget to include SDLmain.h and SDLmain.m your project for the
-# OS X framework based version. (Other versions link to -lSDL2main which
-# this module will try to find on your behalf.) Also for OS X, this
-# module will automatically add the -framework Cocoa on your behalf.
-#
-#
-# Additional Note: If you see an empty SDL2_LIBRARY_TEMP in your configuration
-# and no SDL2_LIBRARY, it means CMake did not find your SDL2 library
-# (SDL2.dll, libsdl2.so, SDL2.framework, etc).
-# Set SDL2_LIBRARY_TEMP to point to your SDL2 library, and configure again.
-# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
-# as appropriate. These values are used to generate the final SDL2_LIBRARY
-# variable, but when these values are unset, SDL2_LIBRARY does not get created.
-#
-#
-# $SDL2DIR is an environment variable that would
-# correspond to the ./configure --prefix=$SDL2DIR
-# used in building SDL2.
-# l.e.galup  9-20-02
-#
-# Modified by Eric Wing.
-# Added code to assist with automated building by using environmental variables
-# and providing a more controlled/consistent search behavior.
-# Added new modifications to recognize OS X frameworks and
-# additional Unix paths (FreeBSD, etc).
-# Also corrected the header search path to follow "proper" SDL guidelines.
-# Added a search for SDL2main which is needed by some platforms.
-# Added a search for threads which is needed by some platforms.
-# Added needed compile switches for MinGW.
-#
-# On OSX, this will prefer the Framework version (if found) over others.
-# People will have to manually change the cache values of
-# SDL2_LIBRARY to override this selection or set the CMake environment
-# CMAKE_INCLUDE_PATH to modify the search paths.
-#
-# Note that the header path has changed from SDL2/SDL.h to just SDL.h
-# This needed to change because "proper" SDL convention
-# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
-# reasons because not all systems place things in SDL2/ (see FreeBSD).
+# Set up architectures (for windows) and prefixes (for mingw builds)
+if(WIN32)
+	if(MINGW)
+		include(MinGWSearchPathExtras OPTIONAL)
+		if(MINGWSEARCH_TARGET_TRIPLE)
+			set(SDL2_PREFIX ${MINGWSEARCH_TARGET_TRIPLE})
+		endif()
+	endif()
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+		set(SDL2_LIB_PATH_SUFFIX lib/x64)
+		if(NOT MSVC AND NOT SDL2_PREFIX)
+			set(SDL2_PREFIX x86_64-w64-mingw32)
+		endif()
+	else()
+		set(SDL2_LIB_PATH_SUFFIX lib/x86)
+		if(NOT MSVC AND NOT SDL2_PREFIX)
+			set(SDL2_PREFIX i686-w64-mingw32)
+		endif()
+	endif()
+endif()
 
-#=============================================================================
-# Copyright 2003-2009 Kitware, Inc.
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
-# (To distribute this file outside of CMake, substitute the full
-#  License text for the above reference.)
+if(SDL2_PREFIX)
+	set(SDL2_ORIGPREFIXPATH ${CMAKE_PREFIX_PATH})
+	if(SDL2_ROOT_DIR)
+		list(APPEND CMAKE_PREFIX_PATH "${SDL2_ROOT_DIR}")
+	endif()
+	if(CMAKE_PREFIX_PATH)
+		foreach(_prefix ${CMAKE_PREFIX_PATH})
+			list(APPEND CMAKE_PREFIX_PATH "${_prefix}/${SDL2_PREFIX}")
+		endforeach()
+	endif()
+	if(MINGWSEARCH_PREFIXES)
+		list(APPEND CMAKE_PREFIX_PATH ${MINGWSEARCH_PREFIXES})
+	endif()
+endif()
 
-# message("<FindSDL2.cmake>")
+# Invoke pkgconfig for hints
+find_package(PkgConfig QUIET)
+set(SDL2_INCLUDE_HINTS)
+set(SDL2_LIB_HINTS)
+if(PKG_CONFIG_FOUND)
+	pkg_search_module(SDL2PC QUIET sdl2)
+	if(SDL2PC_INCLUDE_DIRS)
+		set(SDL2_INCLUDE_HINTS ${SDL2PC_INCLUDE_DIRS})
+	endif()
+	if(SDL2PC_LIBRARY_DIRS)
+		set(SDL2_LIB_HINTS ${SDL2PC_LIBRARY_DIRS})
+	endif()
+endif()
 
-SET(SDL2_SEARCH_PATHS
-	~/Library/Frameworks
-	/Library/Frameworks
-	/usr/local
-	/usr
-	/sw # Fink
-	/opt/local # DarwinPorts
-	/opt/csw # Blastwave
-	/opt
-	${SDL2_PATH}
-)
+include(FindPackageHandleStandardArgs)
 
-FIND_PATH(SDL2_INCLUDE_DIR SDL.h
+find_library(SDL2_LIBRARY
+	NAMES
+	SDL2
 	HINTS
-	$ENV{SDL2DIR}
-	PATH_SUFFIXES include/SDL2 include
-	PATHS ${SDL2_SEARCH_PATHS}
-)
+	${SDL2_LIB_HINTS}
+	PATHS
+	${SDL2_ROOT_DIR}
+	ENV SDL2DIR
+	PATH_SUFFIXES lib SDL2 ${SDL2_LIB_PATH_SUFFIX})
 
-if(CMAKE_SIZEOF_VOID_P EQUAL 8) 
-	set(PATH_SUFFIXES lib64 lib/x64 lib)
-else() 
-	set(PATH_SUFFIXES lib/x86 lib)
-endif() 
-
-FIND_LIBRARY(SDL2_LIBRARY_TEMP
-	NAMES SDL2
-	HINTS
-	$ENV{SDL2DIR}
-	PATH_SUFFIXES ${PATH_SUFFIXES}
-	PATHS ${SDL2_SEARCH_PATHS}
-)
-
-IF(NOT SDL2_BUILDING_LIBRARY)
-	IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
-		# Non-OS X framework versions expect you to also dynamically link to
-		# SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
-		# seem to provide SDL2main for compatibility even though they don't
-		# necessarily need it.
-		FIND_LIBRARY(SDL2MAIN_LIBRARY
-			NAMES SDL2main
+set(_sdl2_framework FALSE)
+# Some special-casing if we've found/been given a framework.
+# Handles whether we're given the library inside the framework or the framework itself.
+if(APPLE AND "${SDL2_LIBRARY}" MATCHES "(/[^/]+)*.framework(/.*)?$")
+	set(_sdl2_framework TRUE)
+	set(SDL2_FRAMEWORK "${SDL2_LIBRARY}")
+	# Move up in the directory tree as required to get the framework directory.
+	while("${SDL2_FRAMEWORK}" MATCHES "(/[^/]+)*.framework(/.*)$" AND NOT "${SDL2_FRAMEWORK}" MATCHES "(/[^/]+)*.framework$")
+		get_filename_component(SDL2_FRAMEWORK "${SDL2_FRAMEWORK}" DIRECTORY)
+	endwhile()
+	if("${SDL2_FRAMEWORK}" MATCHES "(/[^/]+)*.framework$")
+		set(SDL2_FRAMEWORK_NAME ${CMAKE_MATCH_1})
+		# If we found a framework, do a search for the header ahead of time that will be more likely to get the framework header.
+		find_path(SDL2_INCLUDE_DIR
+			NAMES
+			SDL_haptic.h # this file was introduced with SDL2
 			HINTS
-			$ENV{SDL2DIR}
-			PATH_SUFFIXES ${PATH_SUFFIXES}
-			PATHS ${SDL2_SEARCH_PATHS}
-		)
-	ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
-ENDIF(NOT SDL2_BUILDING_LIBRARY)
+			"${SDL2_FRAMEWORK}/Headers/")
+	else()
+		# For some reason we couldn't get the framework directory itself.
+		# Shouldn't happen, but might if something is weird.
+		unset(SDL2_FRAMEWORK)
+	endif()
+endif()
 
-# SDL2 may require threads on your system.
-# The Apple build may not need an explicit flag because one of the
-# frameworks may already provide it.
-# But for non-OSX systems, I will use the CMake Threads package.
-IF(NOT APPLE)
-	FIND_PACKAGE(Threads)
-ENDIF(NOT APPLE)
+find_path(SDL2_INCLUDE_DIR
+	NAMES
+	SDL_haptic.h # this file was introduced with SDL2
+	HINTS
+	${SDL2_INCLUDE_HINTS}
+	PATHS
+	${SDL2_ROOT_DIR}
+	ENV SDL2DIR
+	PATH_SUFFIXES include include/sdl2 include/SDL2 SDL2)
 
-# MinGW needs an additional link flag, -mwindows
-# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -mwindows
-IF(MINGW)
-	SET(MINGW32_LIBRARY mingw32 "-mwindows" CACHE STRING "mwindows for MinGW")
-ENDIF(MINGW)
+if(WIN32 AND SDL2_LIBRARY)
+	find_file(SDL2_RUNTIME_LIBRARY
+		NAMES
+		SDL2.dll
+		libSDL2.dll
+		HINTS
+		${SDL2_LIB_HINTS}
+		PATHS
+		${SDL2_ROOT_DIR}
+		ENV SDL2DIR
+		PATH_SUFFIXES bin lib ${SDL2_LIB_PATH_SUFFIX})
+endif()
 
-IF(SDL2_LIBRARY_TEMP)
-	# For SDL2main
-	IF(NOT SDL2_BUILDING_LIBRARY)
-		IF(SDL2MAIN_LIBRARY)
-			SET(SDL2_LIBRARY_TEMP ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARY_TEMP})
-		ENDIF(SDL2MAIN_LIBRARY)
-	ENDIF(NOT SDL2_BUILDING_LIBRARY)
 
-	# For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
-	# CMake doesn't display the -framework Cocoa string in the UI even
-	# though it actually is there if I modify a pre-used variable.
-	# I think it has something to do with the CACHE STRING.
-	# So I use a temporary variable until the end so I can set the
-	# "real" variable in one-shot.
-	IF(APPLE)
-		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} "-framework Cocoa")
-	ENDIF(APPLE)
+if(WIN32 OR ANDROID OR IOS OR (APPLE AND NOT _sdl2_framework))
+	set(SDL2_EXTRA_REQUIRED SDL2_SDLMAIN_LIBRARY)
+	find_library(SDL2_SDLMAIN_LIBRARY
+		NAMES
+		SDL2main
+		PATHS
+		${SDL2_ROOT_DIR}
+		ENV SDL2DIR
+		PATH_SUFFIXES lib ${SDL2_LIB_PATH_SUFFIX})
+endif()
 
-	# For threads, as mentioned Apple doesn't need this.
-	# In fact, there seems to be a problem if I used the Threads package
-	# and try using this line, so I'm just skipping it entirely for OS X.
-	IF(NOT APPLE)
-		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
-	ENDIF(NOT APPLE)
+if(MINGW AND NOT SDL2PC_FOUND)
+	find_library(SDL2_MINGW_LIBRARY mingw32)
+	find_library(SDL2_MWINDOWS_LIBRARY mwindows)
+endif()
 
-	# For MinGW library
-	IF(MINGW)
-		SET(SDL2_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
-	ENDIF(MINGW)
+if(SDL2_PREFIX)
+	# Restore things the way they used to be.
+	set(CMAKE_PREFIX_PATH ${SDL2_ORIGPREFIXPATH})
+endif()
 
-	# Set the final string here so the GUI reflects the final state.
-	SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
-	# Set the temp variable to INTERNAL so it is not seen in the CMake GUI
-	SET(SDL2_LIBRARY_TEMP "${SDL2_LIBRARY_TEMP}" CACHE INTERNAL "")
-ENDIF(SDL2_LIBRARY_TEMP)
+# handle the QUIETLY and REQUIRED arguments and set QUATLIB_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SDL2
+	DEFAULT_MSG
+	SDL2_LIBRARY
+	SDL2_INCLUDE_DIR
+	${SDL2_EXTRA_REQUIRED})
 
-# message("</FindSDL2.cmake>")
+if(SDL2_FOUND)
+	if(NOT TARGET SDL2::SDL2)
+		# Create SDL2::SDL2
+		if(WIN32 AND SDL2_RUNTIME_LIBRARY)
+			set(SDL2_DYNAMIC TRUE)
+			add_library(SDL2::SDL2 SHARED IMPORTED)
+			set_target_properties(SDL2::SDL2
+				PROPERTIES
+				IMPORTED_IMPLIB "${SDL2_LIBRARY}"
+				IMPORTED_LOCATION "${SDL2_RUNTIME_LIBRARY}"
+				INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIR}"
+			)
+		else()
+			add_library(SDL2::SDL2 UNKNOWN IMPORTED)
+			if(SDL2_FRAMEWORK AND SDL2_FRAMEWORK_NAME)
+				# Handle the case that SDL2 is a framework and we were able to decompose it above.
+				set_target_properties(SDL2::SDL2 PROPERTIES
+					IMPORTED_LOCATION "${SDL2_FRAMEWORK}/${SDL2_FRAMEWORK_NAME}")
+			elseif(_sdl2_framework AND SDL2_LIBRARY MATCHES "(/[^/]+)*.framework$")
+				# Handle the case that SDL2 is a framework and SDL_LIBRARY is just the framework itself.
 
-INCLUDE(FindPackageHandleStandardArgs)
+				# This takes the basename of the framework, without the extension,
+				# and sets it (as a child of the framework) as the imported location for the target.
+				# This is the library symlink inside of the framework.
+				set_target_properties(SDL2::SDL2 PROPERTIES
+					IMPORTED_LOCATION "${SDL2_LIBRARY}/${CMAKE_MATCH_1}")
+			else()
+				# Handle non-frameworks (including non-Mac), as well as the case that we're given the library inside of the framework
+				set_target_properties(SDL2::SDL2 PROPERTIES
+					IMPORTED_LOCATION "${SDL2_LIBRARY}")
+			endif()
+			set_target_properties(SDL2::SDL2
+				PROPERTIES
+				INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIR}"
+			)
+		endif()
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)
+		if(APPLE)
+			# Need Cocoa here, is always a framework
+			find_library(SDL2_COCOA_LIBRARY Cocoa)
+			list(APPEND SDL2_EXTRA_REQUIRED SDL2_COCOA_LIBRARY)
+			if(SDL2_COCOA_LIBRARY)
+				set_target_properties(SDL2::SDL2 PROPERTIES
+						IMPORTED_LINK_INTERFACE_LIBRARIES ${SDL2_COCOA_LIBRARY})
+			endif()
+		endif()
+
+
+		# Compute what to do with SDL2main
+		set(SDL2MAIN_LIBRARIES SDL2::SDL2)
+		add_library(SDL2::SDL2main INTERFACE IMPORTED)
+		if(SDL2_SDLMAIN_LIBRARY)
+			add_library(SDL2::SDL2main_real STATIC IMPORTED)
+			set_target_properties(SDL2::SDL2main_real
+				PROPERTIES
+				IMPORTED_LOCATION "${SDL2_SDLMAIN_LIBRARY}")
+			set(SDL2MAIN_LIBRARIES SDL2::SDL2main_real ${SDL2MAIN_LIBRARIES})
+		endif()
+		if(MINGW)
+			# MinGW requires some additional libraries to appear earlier in the link line.
+			if(SDL2PC_LIBRARIES)
+				# Use pkgconfig-suggested extra libraries if available.
+				list(REMOVE_ITEM SDL2PC_LIBRARIES SDL2main SDL2)
+				set(SDL2MAIN_LIBRARIES ${SDL2PC_LIBRARIES} ${SDL2MAIN_LIBRARIES})
+			else()
+				# fall back to extra libraries specified in pkg-config in
+				# an official binary distro of SDL2 for MinGW I downloaded
+				if(SDL2_MINGW_LIBRARY)
+					set(SDL2MAIN_LIBRARIES ${SDL2_MINGW_LIBRARY} ${SDL2MAIN_LIBRARIES})
+				endif()
+				if(SDL2_MWINDOWS_LIBRARY)
+					set(SDL2MAIN_LIBRARIES ${SDL2_MWINDOWS_LIBRARY} ${SDL2MAIN_LIBRARIES})
+				endif()
+			endif()
+			set_target_properties(SDL2::SDL2main
+				PROPERTIES
+				INTERFACE_COMPILE_DEFINITIONS "main=SDL_main")
+		endif()
+		set_target_properties(SDL2::SDL2main
+			PROPERTIES
+			INTERFACE_LINK_LIBRARIES "${SDL2MAIN_LIBRARIES}")
+		
+		if(WIN32)
+			set_property(TARGET SDL2::SDL2 APPEND_STRING PROPERTY
+				INTERFACE_LINK_LIBRARIES "winmm;imm32;version")
+		endif()
+	endif()
+	mark_as_advanced(SDL2_ROOT_DIR)
+endif()
+
+mark_as_advanced(SDL2_LIBRARY
+	SDL2_RUNTIME_LIBRARY
+	SDL2_INCLUDE_DIR
+	SDL2_SDLMAIN_LIBRARY
+	SDL2_COCOA_LIBRARY
+	SDL2_MINGW_LIBRARY
+	SDL2_MWINDOWS_LIBRARY)

--- a/Modules/FindSDL2.cmake
+++ b/Modules/FindSDL2.cmake
@@ -188,7 +188,7 @@ if(SDL2_FOUND)
 			endif()
 			set_target_properties(SDL2::SDL2
 				PROPERTIES
-				INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIR}"
+				INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIR};${SDL2PC_INCLUDE_DIRS}"
 			)
 		endif()
 
@@ -252,8 +252,13 @@ if(SDL2_FOUND)
 			set_property(TARGET SDL2::SDL2 APPEND_STRING PROPERTY
 				INTERFACE_LINK_LIBRARIES ${COREVIDEO} ${COCOA_LIBRARY}
 					${IOKIT} ${FORCEFEEDBACK} ${CARBON_LIBRARY}
-					${COREAUDIO} ${AUDIOTOOLBOX} ${ICONV_LIBRARY}
-			)
+					${COREAUDIO} ${AUDIOTOOLBOX} ${ICONV_LIBRARY})
+		else()
+			# Remove -lSDL2 -lSDL2main from the pkg-config linker line,
+			# to prevent linking against the system library
+			list(REMOVE_ITEM SDL2PC_STATIC_LIBRARIES SDL2main SDL2)
+			set_property(TARGET SDL2::SDL2 APPEND_STRING PROPERTY
+				INTERFACE_LINK_LIBRARIES "${SDL2PC_STATIC_LIBRARIES}")
 		endif()
 	endif()
 	mark_as_advanced(SDL2_ROOT_DIR)

--- a/Modules/FindSDL2_image.cmake
+++ b/Modules/FindSDL2_image.cmake
@@ -58,6 +58,8 @@ else()
     set(VC_LIB_PATH_SUFFIX lib/x86)
 endif()
 
+find_package(SDL2 REQUIRED)
+
 find_library(SDL2_IMAGE_LIBRARY
         NAMES SDL2_image
         HINTS
@@ -66,6 +68,9 @@ find_library(SDL2_IMAGE_LIBRARY
         PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
         PATHS ${SDL2_IMAGE_PATH}
         )
+
+find_package(PNG)
+find_package(JPEG)
 
 if(SDL2_IMAGE_INCLUDE_DIR AND EXISTS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h")
     file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL2_IMAGE_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_IMAGE_MAJOR_VERSION[ \t]+[0-9]+$")
@@ -81,6 +86,24 @@ if(SDL2_IMAGE_INCLUDE_DIR AND EXISTS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h")
     unset(SDL2_IMAGE_VERSION_MAJOR)
     unset(SDL2_IMAGE_VERSION_MINOR)
     unset(SDL2_IMAGE_VERSION_PATCH)
+
+    if(NOT TARGET SDL2::IMAGE)
+        set(SDL_DEPS_INCLUDE_DIRS ${SDL2_INCLUDE_DIR} ${SDL2_IMAGE_INCLUDE_DIR})
+        set(SDL_DEPS_LIBS SDL2::SDL2)
+        if(PNG_FOUND)
+            list(APPEND SDL_DEPS_LIBS PNG::PNG)
+        endif()
+        if(JPEG_FOUND)
+            list(APPEND SDL_DEPS_LIBS ${JPEG_LIBRARY})
+        endif()
+
+        add_library(SDL2::IMAGE UNKNOWN IMPORTED)
+        set_target_properties(SDL2::IMAGE PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${SDL_DEPS_INCLUDE_DIRS}"
+            IMPORTED_LOCATION "${SDL2_IMAGE_LIBRARY}"
+            INTERFACE_LINK_LIBRARIES "${SDL_DEPS_LIBS}")
+        unset(SDL_DEPS_INCLUDE_DIRS)
+    endif()
 endif()
 
 set(SDL2_IMAGE_LIBRARIES ${SDL2_IMAGE_LIBRARY})

--- a/gencache/CMakeLists.txt
+++ b/gencache/CMakeLists.txt
@@ -11,5 +11,7 @@ add_executable(gencache src/main.cpp)
 
 target_link_libraries(gencache ICU::uc ICU::data)
 
+target_compile_features(gencache PRIVATE cxx_std_11)
+
 include(GNUInstallDirs)
 install(TARGETS gencache RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/gencache/CMakeLists.txt
+++ b/gencache/CMakeLists.txt
@@ -3,6 +3,8 @@ project(gencache VERSION 1.0 LANGUAGES CXX)
 
 set(CMAKE_MODULE_PATH APPEND "${CMAKE_CURRENT_SOURCE_DIR}/../Modules")
 
+include(ConfigureWindows)
+
 find_package(ICU COMPONENTS uc data REQUIRED)
 
 add_executable(gencache src/main.cpp)

--- a/lcf2xml/CMakeLists.txt
+++ b/lcf2xml/CMakeLists.txt
@@ -3,10 +3,7 @@ project(lcf2xml VERSION 1.0 LANGUAGES CXX)
 
 set(CMAKE_MODULE_PATH APPEND "${CMAKE_CURRENT_SOURCE_DIR}/../Modules")
 
-if(MSVC)
-	# Exception handling
-	set_property(TARGET lcf2xml PROPERTY COMPILE_FLAGS "/EHsc")
-endif()
+include(ConfigureWindows)
 
 find_package(liblcf REQUIRED)
 

--- a/lmu2png/CMakeLists.txt
+++ b/lmu2png/CMakeLists.txt
@@ -5,14 +5,16 @@ set(CMAKE_MODULE_PATH APPEND "${CMAKE_CURRENT_SOURCE_DIR}/../Modules")
 
 include(ConfigureWindows)
 
+find_package(ZLIB REQUIRED)
 find_package(liblcf REQUIRED)
 find_package(SDL2_image REQUIRED)
 
 add_executable(lmu2png
+	src/sdlxyz.cpp
 	src/chipset.cpp
 	src/main.cpp)
 
-target_link_libraries(lmu2png SDL2::IMAGE liblcf::liblcf)
+target_link_libraries(lmu2png ZLIB::ZLIB SDL2::IMAGE liblcf::liblcf)
 
 target_compile_features(lmu2png PRIVATE cxx_std_11)
 

--- a/lmu2png/CMakeLists.txt
+++ b/lmu2png/CMakeLists.txt
@@ -3,10 +3,7 @@ project(lmu2png VERSION 1.0 LANGUAGES CXX)
 
 set(CMAKE_MODULE_PATH APPEND "${CMAKE_CURRENT_SOURCE_DIR}/../Modules")
 
-if(MSVC)
-	# Exception handling
-	set_property(TARGET lmu2png PROPERTY COMPILE_FLAGS "/EHsc")
-endif()
+include(ConfigureWindows)
 
 find_package(liblcf REQUIRED)
 find_package(SDL2_image REQUIRED)

--- a/lmu2png/CMakeLists.txt
+++ b/lmu2png/CMakeLists.txt
@@ -14,5 +14,7 @@ add_executable(lmu2png
 
 target_link_libraries(lmu2png SDL2::IMAGE liblcf::liblcf)
 
+target_compile_features(lmu2png PRIVATE cxx_std_11)
+
 include(GNUInstallDirs)
 install(TARGETS lmu2png RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/png2xyz/CMakeLists.txt
+++ b/png2xyz/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.7)
 project(png2xyz VERSION 1.0 LANGUAGES CXX)
 
+set(CMAKE_MODULE_PATH APPEND "${CMAKE_CURRENT_SOURCE_DIR}/../Modules")
+
+include(ConfigureWindows)
+
 find_package(PNG REQUIRED)
 
 add_executable(png2xyz src/png2xyz.cpp)

--- a/xyz2png/CMakeLists.txt
+++ b/xyz2png/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.7)
 project(xyz2png VERSION 1.0 LANGUAGES CXX)
 
+set(CMAKE_MODULE_PATH APPEND "${CMAKE_CURRENT_SOURCE_DIR}/../Modules")
+
+include(ConfigureWindows)
+
 find_package(PNG REQUIRED)
 
 add_executable(xyz2png src/xyz2png.cpp)

--- a/xyzcrush/CMakeLists.txt
+++ b/xyzcrush/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.7)
 project(xyzcrush VERSION 1.0 LANGUAGES C CXX)
 
+set(CMAKE_MODULE_PATH APPEND "${CMAKE_CURRENT_SOURCE_DIR}/../Modules")
+
+include(ConfigureWindows)
+
 find_package(ZLIB REQUIRED)
 
 add_library(zopfli


### PR DESCRIPTION
Fixes the incorrect setting of /Ehsc as explained earlier.

Also setting Unicode by default now and disabling "this api is insecure" warnings.
Shared and static runtime library can be configured now.

Will use that helper in all our repos from now on, sad that CMake doesn't have this built-in.

Sorry for the huge SDL2[image].cmake change again. Looks like I messed up and reverted the files one commit after I updated them :/, sorry. (or forgot git add, no idea).

Tested building under Windows and Linux.
Going to test MacOS tomorrow.