### PR TITLE
xyz-thumbnailer: Fix Windows x64 install script

### DIFF
--- a/xyz-thumbnailer/windows/bin/install.cmd
+++ b/xyz-thumbnailer/windows/bin/install.cmd
@@ -14,7 +14,7 @@ set "batchPath=%~dp0"
 setlocal EnableDelayedExpansion
 
 :: 64bit check
-IF "%PROCESSOR_ARCHITECTURE%"=="x86" (set bit=x86) else (set bit=amd64)
+IF "%PROCESSOR_ARCHITECTURE%"=="x86" (set bit=x86) else (set bit=x64)
 
 :: Elevate to admin and run regsvr32
 


### PR DESCRIPTION
Guess Visual Studio changed the name of the amd64 folder to x64 a while ago which broke the install.cmd script