### PR TITLE
Add support for wildcards in LCF2XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Tool details
 
 These are the currently available tools:
 
- * LCF2XML: converts LMU, LMT, LDB and LSD files into XML and vice-versa.
+ * LCF2XML: converts LMU, LMT, LDB and LSD files into XML and vice versa. It supports
+            wildcards.
 
-   Syntax: `lcf2xml inputfile outputfile`
+   Syntax: `lcf2xml file1 [... fileN]`
 
  * LMU2PNG: renders LMU maps to PNG images with events as tiles support.
 
@@ -40,7 +41,7 @@ These are the currently available tools:
    Syntax: `gencache [Options] [Directory]`
 
  * xyz-thumbnailer: displays thumbnails for XYZ files in your file manager
-                    (currently Windows and Linux/GTK3/KDE5 only)
+                    (currently Windows and Linux/GTK3/KDE5 only).
 
    Windows: Shell extension for Windows explorer, see included README.md for
             install instructions.


### PR DESCRIPTION
This backports https://github.com/EasyRPG/Tools/commit/ae6a4fb13a805c736035ecc401422cc140142cda from @Zegeri's `wip` branch and updates syntax from documentation.

Note the syntax changed, so if you already use `lcf2xml` in your tests or automated stuff, please update. It also changes resulting filenames to match the current on Editor-Qt.

Closes #37.