### PR TITLE
Windows: Fix XYZ Thumbnailer.

### DIFF
--- a/xyz-thumbnailer/windows/CMakeLists.txt
+++ b/xyz-thumbnailer/windows/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(xyz_thumbnailer SHARED
 	dllmain.cpp
 	Reg.cpp
 	RpgMakerXyzThumbnailProvider.cpp
+	GlobalExportFunctions.def
 )
 
 set_target_properties(xyz_thumbnailer PROPERTIES OUTPUT_NAME "EasyRpgXyzShellExtThumbnailHandler")

--- a/xyz-thumbnailer/windows/Reg.cpp
+++ b/xyz-thumbnailer/windows/Reg.cpp
@@ -10,6 +10,7 @@ WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
 #include "Reg.h"
 #include <strsafe.h>
+#include <Objbase.h>
 
 
 #pragma region Registry Helper Functions


### PR DESCRIPTION
Did not compile anymore and the DLL functions were not exported