### PR TITLE
lcftrans: Add new mode "Match".

### DIFF
--- a/lcftrans/src/entry.cpp
+++ b/lcftrans/src/entry.cpp
@@ -43,3 +43,7 @@ void Entry::write(std::ostream& out) const {
 	write_n(out, original, "msgid");
 	write_n(out, translation, "msgstr");
 }
+
+bool Entry::hasTranslation() const {
+	return !(translation.size() == 1 && translation[0].empty());
+}

--- a/lcftrans/src/entry.h
+++ b/lcftrans/src/entry.h
@@ -17,8 +17,11 @@ public:
 	std::string context; // msgctxt
 	std::vector<std::string> info; // #.
 	std::string location; // #: // Unused, maybe useful later
+	bool fuzzy = false; // When true write a "#, fuzzy" marker
 
 	void write(std::ostream& out) const;
+
+	bool hasTranslation() const;
 };
 
 #endif

--- a/lcftrans/src/translation.h
+++ b/lcftrans/src/translation.h
@@ -29,6 +29,15 @@ public:
 
 	Translation Merge(const Translation& from);
 
+	/**
+	 * Takes the msgids of from and attempts to match them against msgid of
+	 * this. When matched the msgid of from is copied to msgstr of this.
+	 * @param from Translation to match from
+	 * @param matched Number of matches
+	 * @return Entries that failed to match
+	 */
+	Translation Match(const Translation& from, int& matches);
+
 	static TranslationLdb fromLDB(const std::string& filename, const std::string& encoding);
 	static Translation fromLMT(const std::string& filename, const std::string& encoding);
 	static Translation fromLMU(const std::string& filename, const std::string& encoding);


### PR DESCRIPTION
This takes two folders with Po-Files and attempts to match the source text with the target text.
Very useful to generate translation files from games that have hardcoded translations directly in the game files.

Assuming you have two translated games. e.g. Vampires Dawn de and en.

First you create two new translations from the two translated game versions:

```
# Create translation dirs
mkdir -p vd1_de/languages/de vd1_de/languages/en vd1_de/languages/en_matched

# Dump German strings in languages/de
lcftrans -c -o vd1_de/languages/de vd1_de 1252

# Dump English strings in languages/en
lcftrans -c -o vd1_de/languages/en vd1_en 1252
```

Then you match them:

```
# Match English strings with German strings.
# The English strings are now the translation of the German strings.
# (put in languages/en_matched)
lcftrans -m vd1_de/languages/en -o vd1_de/languages/en_matched vd1_de/languages/de
```

Image:
Left German, Middle English, Right Merged
There are "#, fuzzy" markers when the line did not match (so the translation that was put there could be wrong)

![Screenshot_20210308_143342-fs8](https://user-images.githubusercontent.com/1331889/110328295-775d2f00-801b-11eb-981e-115f24182f8e.png)

