### PR TITLE
Allow autotools to detect pre-3.9.0 nlohmann_json

### DIFF
--- a/gencache/configure.ac
+++ b/gencache/configure.ac
@@ -11,6 +11,10 @@ AC_PROG_CXXCPP
 AC_PROG_CXX
 
 PKG_CHECK_MODULES([ICU], [icu-i18n])
-PKG_CHECK_MODULES([NLOHMANNJSON], [nlohmann_json])
+PKG_CHECK_MODULES([NLOHMANNJSON], [nlohmann_json],,[
+	AC_CHECK_HEADER([nlohmann/json.hpp],,[
+		AC_MSG_ERROR([Could not find 'nlohmann_json' package! Consider installing version 3.9.0 or newer.])
+	],[ ])
+])
 
 AC_OUTPUT


### PR DESCRIPTION
Just works if it is in a path added by `$CPPFLAGS` or default (e.g. /usr/include)

Otherwise it is still possible to override `$NLOHMANNJSON_CFLAGS` on configure invocation, if needed.