### PR TITLE
Lcftrans enhancements

### DIFF
--- a/lcftrans/src/entry.cpp
+++ b/lcftrans/src/entry.cpp
@@ -45,5 +45,5 @@ void Entry::write(std::ostream& out) const {
 }
 
 bool Entry::hasTranslation() const {
-	return !(translation.size() == 1 && translation[0].empty());
+	return !translation.empty() && !(translation.size() == 1 && translation[0].empty());
 }

--- a/lcftrans/src/main.cpp
+++ b/lcftrans/src/main.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <lcf/encoder.h>
 #include <lcf/reader_util.h>
+#include <lcf/ldb/reader.h>
 
 #include "translation.h"
 #include "utils.h"
@@ -17,6 +18,7 @@
 #include "dirent_win.h"
 #else
 #include <dirent.h>
+
 #endif
 
 #define DATABASE_FILE "rpg_rt.ldb"
@@ -178,9 +180,9 @@ int main(int argc, char** argv) {
 			encoding = lcf::ReaderUtil::GetEncoding(ini_file);
 		}
 		if (encoding.empty() && !database_file.empty()) {
-			std::ifstream i(database_file, std::ios::binary);
-			if (i) {
-				encoding = lcf::ReaderUtil::DetectEncoding(i);
+			auto db = lcf::LDB_Reader::Load(database_file, encoding);
+			if (db) {
+				encoding = lcf::ReaderUtil::DetectEncoding(*db);
 			}
 		}
 	}

--- a/lcftrans/src/translation.cpp
+++ b/lcftrans/src/translation.cpp
@@ -97,7 +97,7 @@ Translation Translation::Merge(const Translation& from) {
 
 	// Ignore strings that don't have a translation at all
 	efrom.erase(
-		std::remove_if(efrom.begin(), efrom.end(), [](Entry &e) { return e.translation.empty(); }),
+		std::remove_if(efrom.begin(), efrom.end(), [](Entry &e) { return !e.hasTranslation(); }),
 	efrom.end());
 
 	// Copy over and find stale entries (entries that are not available in the new translation anymore)

--- a/lcftrans/src/translation.cpp
+++ b/lcftrans/src/translation.cpp
@@ -538,7 +538,7 @@ Translation Translation::fromPO(const std::string& filename) {
 		// Parse multiply lines until empty line or comment
 		std::string msgstr = extract_string(6);
 
-		while (std::getline(in, line, '\n')) {
+		while (Utils::ReadLine(in, line)) {
 			std::cout << line << "\n";
 			++line_number;
 			if (line.empty() || starts_with("#")) {
@@ -557,7 +557,7 @@ Translation Translation::fromPO(const std::string& filename) {
 		// Parse multiply lines until empty line or msgstr is encountered
 		std::string msgid = extract_string(5);
 
-		while (std::getline(in, line, '\n')) {
+		while (Utils::ReadLine(in, line)) {
 			std::cout << line << "\n";
 			++line_number;
 			if (line.empty() || starts_with("msgstr")) {
@@ -578,7 +578,7 @@ Translation Translation::fromPO(const std::string& filename) {
 		// Parse multiply lines until empty line, msgctxt or msgid is encountered
 		e.info.push_back(line.substr(3));
 
-		while (std::getline(in, line, '\n')) {
+		while (Utils::ReadLine(in, line)) {
 			if (line.empty() || starts_with("msgctx") || starts_with("msgid")) {
 				if (starts_with("msgctx")) {
 					read_msgctx();
@@ -598,7 +598,7 @@ Translation Translation::fromPO(const std::string& filename) {
 		}
 	};
 
-	while (std::getline(in, line, '\n')) {
+	while (Utils::ReadLine(in, line)) {
 		std::cout << line << "\n";
 		++line_number;
 		if (!found_header) {

--- a/lcftrans/src/translation.cpp
+++ b/lcftrans/src/translation.cpp
@@ -229,9 +229,11 @@ public:
 		Entry e;
 		e.original = lines;
 		e.info = info;
+		e.context = context;
 		t.addEntry(e);
 		lines.clear();
 		info.clear();
+		context.clear();
 	};
 
 	template<typename T>
@@ -284,6 +286,22 @@ public:
 				add_evt_entry();
 			}
 				break;
+			case Cmd::ChangeHeroName:
+				add_evt_entry();
+				info.push_back(make_info(ctx));
+				info.push_back("ChangeHeroName (Actor " + std::to_string(ctx.obj->parameters[0]) + ")");
+				lines.push_back(Utils::RemoveControlChars(estring));
+				context = "actors.name";
+				add_evt_entry();
+				break;
+			case Cmd::ChangeHeroTitle:
+				add_evt_entry();
+				info.push_back(make_info(ctx));
+				info.push_back("ChangeHeroTitle (Actor " + std::to_string(ctx.obj->parameters[0]) + ")");
+				lines.push_back(Utils::RemoveControlChars(estring));
+				context = "actors.title";
+				add_evt_entry();
+				break;
 			default:
 				break;
 		}
@@ -296,6 +314,7 @@ public:
 private:
 	std::vector<std::string> lines;
 	std::vector<std::string> info;
+	std::string context;
 	int prev_evt_id = 0;
 	int prev_line = 0;
 	int prev_indent = 0;

--- a/lcftrans/src/translation.cpp
+++ b/lcftrans/src/translation.cpp
@@ -473,10 +473,6 @@ Translation Translation::fromPO(const std::string& filename) {
 
 	Entry e;
 
-	auto starts_with = [&line_view](const std::string& search) {
-		return line_view.find(search) == 0;
-	};
-
 	auto extract_string = [&](int offset) -> std::string {
 		if (offset >= line_view.size()) {
 			std::cerr << "Parse error (Line " << line_number << ") is empty\n";
@@ -542,7 +538,7 @@ Translation Translation::fromPO(const std::string& filename) {
 		while (Utils::ReadLine(in, line)) {
 			line_view = Utils::TrimWhitespace(line);
 			++line_number;
-			if (line_view.empty() || starts_with("#")) {
+			if (line_view.empty() || line_view.starts_with("#")) {
 				break;
 			}
 			msgstr += extract_string(0);
@@ -561,7 +557,7 @@ Translation Translation::fromPO(const std::string& filename) {
 		while (Utils::ReadLine(in, line)) {
 			line_view = Utils::TrimWhitespace(line);
 			++line_number;
-			if (line_view.empty() || starts_with("msgstr")) {
+			if (line_view.empty() || line_view.starts_with("msgstr")) {
 				e.original = Utils::Split(msgid);
 				read_msgstr();
 				return;
@@ -580,15 +576,16 @@ Translation Translation::fromPO(const std::string& filename) {
 		e.info.push_back(line.substr(3));
 
 		while (Utils::ReadLine(in, line)) {
-			if (line.empty() || starts_with("msgctx") || starts_with("msgid")) {
-				if (starts_with("msgctx")) {
+			line_view = Utils::TrimWhitespace(line);
+			if (line.empty() || line_view.starts_with("msgctx") || line_view.starts_with("msgid")) {
+				if (line_view.starts_with("msgctx")) {
 					read_msgctx();
-				} else if (starts_with("msgid")) {
+				} else if (line_view.starts_with("msgid")) {
 					read_msgid();
 				}
 				return;
 			}
-			else if (starts_with("#.")) {
+			else if (line_view.starts_with("#.")) {
 				if (line.length() > 3) {
 					e.info.push_back(line.substr(3));
 				}
@@ -603,27 +600,27 @@ Translation Translation::fromPO(const std::string& filename) {
 		line_view = Utils::TrimWhitespace(line);
 		++line_number;
 		if (!found_header) {
-			if (starts_with("msgstr")) {
+			if (line_view.starts_with("msgstr")) {
 				found_header = true;
 			}
 			continue;
 		}
 
 		if (!parse_item) {
-			if (starts_with("#.")) {
+			if (line_view.starts_with("#.")) {
 				parse_item = true;
 				read_info();
-			} else if (starts_with("msgctxt")) {
+			} else if (line_view.starts_with("msgctxt")) {
 				read_msgctx();
 				parse_item = true;
-			} else if (starts_with("msgid")) {
+			} else if (line_view.starts_with("msgid")) {
 				parse_item = true;
 				read_msgid();
 			}
 		} else {
-			if (starts_with("msgid")) {
+			if (line_view.starts_with("msgid")) {
 				read_msgid();
-			} else if (starts_with("msgstr")) {
+			} else if (line_view.starts_with("msgstr")) {
 				read_msgstr();
 			}
 		}

--- a/lcftrans/src/translation.cpp
+++ b/lcftrans/src/translation.cpp
@@ -466,18 +466,19 @@ Translation Translation::fromPO(const std::string& filename) {
 	std::ifstream in(filename);
 
 	std::string line;
+	lcf::StringView line_view;
 	bool found_header = false;
 	bool parse_item = false;
 	int line_number = 0;
 
 	Entry e;
 
-	auto starts_with = [&line](const std::string& search) {
-		return line.find(search) == 0;
+	auto starts_with = [&line_view](const std::string& search) {
+		return line_view.find(search) == 0;
 	};
 
 	auto extract_string = [&](int offset) -> std::string {
-		if (offset >= line.size()) {
+		if (offset >= line_view.size()) {
 			std::cerr << "Parse error (Line " << line_number << ") is empty\n";
 			return "";
 		}
@@ -486,7 +487,7 @@ Translation Translation::fromPO(const std::string& filename) {
 		bool slash = false;
 		bool first_quote = false;
 
-		for (char c : line.substr(offset)) {
+		for (char c : line_view.substr(offset)) {
 			if (!first_quote) {
 				if (c == ' ') {
 					continue;
@@ -539,9 +540,9 @@ Translation Translation::fromPO(const std::string& filename) {
 		std::string msgstr = extract_string(6);
 
 		while (Utils::ReadLine(in, line)) {
-			std::cout << line << "\n";
+			line_view = Utils::TrimWhitespace(line);
 			++line_number;
-			if (line.empty() || starts_with("#")) {
+			if (line_view.empty() || starts_with("#")) {
 				break;
 			}
 			msgstr += extract_string(0);
@@ -558,9 +559,9 @@ Translation Translation::fromPO(const std::string& filename) {
 		std::string msgid = extract_string(5);
 
 		while (Utils::ReadLine(in, line)) {
-			std::cout << line << "\n";
+			line_view = Utils::TrimWhitespace(line);
 			++line_number;
-			if (line.empty() || starts_with("msgstr")) {
+			if (line_view.empty() || starts_with("msgstr")) {
 				e.original = Utils::Split(msgid);
 				read_msgstr();
 				return;
@@ -599,7 +600,7 @@ Translation Translation::fromPO(const std::string& filename) {
 	};
 
 	while (Utils::ReadLine(in, line)) {
-		std::cout << line << "\n";
+		line_view = Utils::TrimWhitespace(line);
 		++line_number;
 		if (!found_header) {
 			if (starts_with("msgstr")) {

--- a/lcftrans/src/translation.cpp
+++ b/lcftrans/src/translation.cpp
@@ -596,6 +596,7 @@ Translation Translation::fromPO(const std::string& filename) {
 
 		while (Utils::ReadLine(in, line)) {
 			line_view = Utils::TrimWhitespace(line);
+			++line_number;
 			if (line.empty() || line_view.starts_with("msgctx") || line_view.starts_with("msgid")) {
 				if (line_view.starts_with("msgctx")) {
 					read_msgctx();
@@ -609,7 +610,7 @@ Translation Translation::fromPO(const std::string& filename) {
 					e.info.push_back(line.substr(3));
 				}
 			} else {
-				std::cerr << "Parse error " << line << " (" << line << "). Expected #., msgctx or msgid\n";
+				std::cerr << "Parse error (Line " << line_number << ") " << line << " (" << line << "). Expected #., msgctx or msgid\n";
 				return;
 			}
 		}

--- a/lcftrans/src/utils.h
+++ b/lcftrans/src/utils.h
@@ -11,6 +11,7 @@
 #include <vector>
 #include <lcf/rpg/eventcommand.h>
 #include <lcf/span.h>
+#include <lcf/string_view.h>
 
 namespace Utils {
 	std::string GetFilename(const std::string& str);
@@ -19,6 +20,8 @@ namespace Utils {
 	std::vector<std::string> Split(const std::string& line, char split_char = '\n');
 	std::string LowerCase(const std::string &in);
 	std::string RemoveControlChars(lcf::StringView s);
+	bool ReadLine(std::istream& is, std::string& line_out);
+	lcf::StringView TrimWhitespace(lcf::StringView s);
 
 	std::vector<std::string> GetChoices(lcf::Span<lcf::rpg::EventCommand> list, int start_index);
 

--- a/lcfviz/src/main.cpp
+++ b/lcfviz/src/main.cpp
@@ -19,6 +19,7 @@
 #include <lcf/lmt/reader.h>
 #include <lcf/lmu/reader.h>
 #include <lcf/rpg/treemap.h>
+#include <lcf/ldb/reader.h>
 
 #include "utils.h"
 
@@ -145,9 +146,9 @@ int main(int argc, char** argv) {
 			encoding = lcf::ReaderUtil::GetEncoding(ini_file);
 		}
 		if (encoding.empty() && !database_file.empty()) {
-			std::ifstream i(database_file, std::ios::binary);
-			if (i) {
-				encoding = lcf::ReaderUtil::DetectEncoding(i);
+			auto db = lcf::LDB_Reader::Load(database_file, encoding);
+			if (db) {
+				encoding = lcf::ReaderUtil::DetectEncoding(*db);
 			}
 		}
 	}


### PR DESCRIPTION
The parser is now more robust (no segfaults anymore) and ignores leading and trailing whitespace.

The event commands ChangeHeroName and ChangeHeroTitle are now supported