### PR TITLE
CMake: Update FindSDL2 to Player version and support SDL2_image-static

### DIFF
--- a/Modules/FindSDL2_image.cmake
+++ b/Modules/FindSDL2_image.cmake
@@ -61,7 +61,7 @@ endif()
 find_package(SDL2 REQUIRED)
 
 find_library(SDL2_IMAGE_LIBRARY
-        NAMES SDL2_image
+        NAMES SDL2_image SDL2_image-static
         HINTS
         ENV SDL2IMAGEDIR
         ENV SDL2DIR


### PR DESCRIPTION
as noticed by Käsekumpel a week ago the libraries have now a new name on Windows :/