### PR TITLE
lcftrans: Support ShowStringPicture event command

### DIFF
--- a/lcftrans/src/translation.cpp
+++ b/lcftrans/src/translation.cpp
@@ -313,6 +313,21 @@ public:
 					add_evt_entry();
 				}
 				break;
+			case Cmd::Maniac_ShowStringPicture: {
+				// Show String Picture
+				add_evt_entry();
+				auto tokens = Utils::Split(lcf::ToString(estring), '\x01');
+				if (tokens.size() >= 4) {
+					info.push_back(make_info(ctx));
+					info.push_back("Show String Picture");
+					for (auto& line: Utils::Split(tokens[1], '\n')) {
+						lines.push_back(Utils::RemoveControlChars(line));
+					}
+					context = "strpic";
+					add_evt_entry();
+				}
+				break;
+			}
 			default:
 				break;
 		}

--- a/lcftrans/src/utils.cpp
+++ b/lcftrans/src/utils.cpp
@@ -61,7 +61,7 @@ std::vector<std::string> Utils::Split(const std::string& line, char split_char) 
 	std::string cur_token;
 
 	for (auto c: line) {
-		if (c == '\n') {
+		if (c == split_char) {
 			tokens.push_back(cur_token);
 			cur_token.clear();
 			continue;


### PR DESCRIPTION
:musical_note: We do what we must, because we can :musical_note: 

![image](https://user-images.githubusercontent.com/1331889/205764182-696b7c2e-4806-409e-ba7b-6f3753741b31.png)
