### PR TITLE
gencache: Use C++17 because ICU requires it

### DIFF
--- a/gencache/CMakeLists.txt
+++ b/gencache/CMakeLists.txt
@@ -12,7 +12,7 @@ set(dirent_dir src/external/dirent_win)
 add_executable(gencache
 	src/main.cpp
 	${dirent_dir}/dirent_win.h)
-target_compile_features(gencache PRIVATE cxx_std_14)
+target_compile_features(gencache PRIVATE cxx_std_17)
 target_include_directories(gencache PRIVATE ${dirent_dir})
 target_compile_definitions(gencache PRIVATE
 	PACKAGE_VERSION="${PROJECT_VERSION}"

--- a/gencache/Makefile.am
+++ b/gencache/Makefile.am
@@ -11,7 +11,7 @@ gencache_SOURCES = \
 	src/main.cpp \
 	$(direntdir)/dirent_win.h
 gencache_CXXFLAGS = \
-	-std=c++14 \
+	-std=c++17 \
 	-I$(srcdir)/$(direntdir) \
 	$(ICU_CFLAGS) \
 	$(NLOHMANNJSON_CFLAGS)


### PR DESCRIPTION
Failed to build on Arch Linux