### PR TITLE
lmu2png: fix bad offset on right-edge of terrain autotiles

### DIFF
--- a/lmu2png/src/chipset.cpp
+++ b/lmu2png/src/chipset.cpp
@@ -287,7 +287,7 @@ void Chipset::RenderTerrainTile(FIBITMAP *dest, unsigned short Tile, int Terrain
 						DrawWide(dest, x, y+HALF_TILE, sX+16, sY+56);
 					} else {
 						DrawTall(dest, x,           y, sX,    sY+32);
-						DrawTall(dest, x+HALF_TILE, y, sX+32, sY+32);
+						DrawTall(dest, x+HALF_TILE, y, sX+40, sY+32);
 					}
 					break;
 				case 0x01:


### PR DESCRIPTION
This is a fix for lmu2png. The right edge of terrain autotiles are drawn wrong on one-tile-wide vertical strips.

Before/after this patch:

![Comparison](https://github.com/user-attachments/assets/ade2be1b-6c31-47be-8a8b-a8a9bf4380f6)

This right half of the tile is drawn by this line

https://github.com/EasyRPG/Tools/blob/0772ab7a717aa251a20eaa8097733c41db91b9a7/lmu2png/src/chipset.cpp#L290

Note that this draws the *left* half of the chip into the *right* half of the destination.

![Tile](https://github.com/user-attachments/assets/e14bd037-f3e9-41c0-b957-8bed7413ceae)

I don't understand any of the `Combination` stuff, but I don't think that should ever happen, so I'm guessing this is a typo and it should be drawing the right half of the chip instead ie. the offset needs to move right 8 pixels.