### PR TITLE
Windows: declare UTF-8 through manifest

### DIFF
--- a/Modules/ConfigureWindows.cmake
+++ b/Modules/ConfigureWindows.cmake
@@ -24,3 +24,17 @@ if(MSVC)
 	# Interpret character literals as UTF-8
 	add_compile_options("/utf-8")
 endif()
+
+# Attaches a manifest to make the active codepage UTF-8
+# Caller must ensure ${CMAKE_CURRENT_LIST_DIR}/resources exists
+function(target_use_utf8_codepage_on_windows target)
+	if(WIN32)
+		if(NOT MINGW)
+			target_sources(${target} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/resources/utf8.manifest")
+		# Since CMake in MINGW doesn't support linking
+		# .manifest file, do it with .rc file
+		elseif(MINGW)
+			target_sources(${target} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/resources/utf8.rc")
+		endif()
+	endif()
+endfunction()

--- a/gencache/CMakeLists.txt
+++ b/gencache/CMakeLists.txt
@@ -19,6 +19,7 @@ target_compile_definitions(gencache PRIVATE
 	PACKAGE_BUGREPORT="https://github.com/EasyRPG/Tools/issues"
 	PACKAGE_URL="${PROJECT_HOMEPAGE_URL}")
 target_link_libraries(gencache ICU::uc ICU::data nlohmann_json::nlohmann_json)
+target_use_utf8_codepage_on_windows(gencache)
 
 include(GNUInstallDirs)
 install(TARGETS gencache RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/gencache/resources
+++ b/gencache/resources
@@ -1,0 +1,1 @@
+../resources/

--- a/lcftrans/CMakeLists.txt
+++ b/lcftrans/CMakeLists.txt
@@ -28,6 +28,7 @@ target_compile_definitions(lcftrans PRIVATE
 	PACKAGE_BUGREPORT="https://github.com/EasyRPG/Tools/issues"
 	PACKAGE_URL="${PROJECT_HOMEPAGE_URL}")
 target_link_libraries(lcftrans liblcf::liblcf)
+target_use_utf8_codepage_on_windows(lcftrans)
 
 include(GNUInstallDirs)
 install(TARGETS lcftrans RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/lcftrans/resources
+++ b/lcftrans/resources
@@ -1,0 +1,1 @@
+../resources/

--- a/lcfviz/CMakeLists.txt
+++ b/lcfviz/CMakeLists.txt
@@ -23,6 +23,7 @@ target_compile_definitions(lcfviz PRIVATE
 	PACKAGE_BUGREPORT="https://github.com/EasyRPG/Tools/issues"
 	PACKAGE_URL="${PROJECT_HOMEPAGE_URL}")
 target_link_libraries(lcfviz liblcf::liblcf)
+target_use_utf8_codepage_on_windows(lcfviz)
 
 include(GNUInstallDirs)
 install(TARGETS lcfviz RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/lcfviz/resources
+++ b/lcfviz/resources
@@ -1,0 +1,1 @@
+../resources/

--- a/lmu2png/CMakeLists.txt
+++ b/lmu2png/CMakeLists.txt
@@ -35,6 +35,7 @@ target_compile_definitions(lmu2png PRIVATE
 	PACKAGE_BUGREPORT="https://github.com/EasyRPG/Tools/issues"
 	PACKAGE_URL="${PROJECT_HOMEPAGE_URL}")
 target_link_libraries(lmu2png ZLIB::ZLIB freeimage::FreeImage liblcf::liblcf)
+target_use_utf8_codepage_on_windows(lmu2png)
 
 if(wxWidgets_FOUND)
 	target_compile_definitions(lmu2png PRIVATE WITH_GUI)

--- a/lmu2png/resources
+++ b/lmu2png/resources
@@ -1,0 +1,1 @@
+../resources/

--- a/png2xyz/CMakeLists.txt
+++ b/png2xyz/CMakeLists.txt
@@ -14,6 +14,7 @@ target_compile_definitions(png2xyz PRIVATE
 	PACKAGE_BUGREPORT="https://github.com/EasyRPG/Tools/issues"
 	PACKAGE_URL="${PROJECT_HOMEPAGE_URL}")
 target_link_libraries(png2xyz PNG::PNG ZLIB::ZLIB)
+target_use_utf8_codepage_on_windows(png2xyz)
 
 include(GNUInstallDirs)
 install(TARGETS png2xyz RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/png2xyz/resources
+++ b/png2xyz/resources
@@ -1,0 +1,1 @@
+../resources/

--- a/resources/utf8.manifest
+++ b/resources/utf8.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/resources/utf8.rc
+++ b/resources/utf8.rc
@@ -1,0 +1,3 @@
+#include <winuser.h>
+
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "utf8.manifest"

--- a/xyz2png/CMakeLists.txt
+++ b/xyz2png/CMakeLists.txt
@@ -14,6 +14,7 @@ target_compile_definitions(xyz2png PRIVATE
 	PACKAGE_BUGREPORT="https://github.com/EasyRPG/Tools/issues"
 	PACKAGE_URL="${PROJECT_HOMEPAGE_URL}")
 target_link_libraries(xyz2png PNG::PNG ZLIB::ZLIB)
+target_use_utf8_codepage_on_windows(xyz2png)
 
 include(GNUInstallDirs)
 install(TARGETS xyz2png RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/xyz2png/resources
+++ b/xyz2png/resources
@@ -1,0 +1,1 @@
+../resources/

--- a/xyzcrush/CMakeLists.txt
+++ b/xyzcrush/CMakeLists.txt
@@ -40,6 +40,7 @@ target_compile_definitions(xyzcrush PRIVATE
 	PACKAGE_BUGREPORT="https://github.com/EasyRPG/Tools/issues"
 	PACKAGE_URL="${PROJECT_HOMEPAGE_URL}")
 target_link_libraries(xyzcrush zopfli ZLIB::ZLIB)
+target_use_utf8_codepage_on_windows(xyzcrush)
 
 include(GNUInstallDirs)
 install(TARGETS xyzcrush RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/xyzcrush/resources
+++ b/xyzcrush/resources
@@ -1,0 +1,1 @@
+../resources/


### PR DESCRIPTION
Fixes #61. Fixes #86.

Attaches a manifest to Windows .exes which makes `char*`s (narrow char strings) like `argv` be encoded in UTF-8, allowing tools to operate on files that can't be written in the system's narrow char encoding (eg. Japanese filenames on a Latin-1 system).

This is basically copy-pasted from the way libjxl/libavif does it.

All the tools are changed except xyz-thumbnailer (I didn't look into that one).

For lmu2png specifically, I believe it also fixes a bug where [a narrow char path and a UTF-8 string are concatenated](https://github.com/EasyRPG/Tools/blob/1eb6fbd98a508510093891438c3267620b2bcf21/lmu2png/src/utils.cpp#L79-L80). This implicitly assumes the narrow char encoding is UTF-8. Previously, Japanese games wouldn't work on Windows even when the system narrow char encoding was Shift JIS.

More points:

* Will not work on Windows older than Windows 10 2019 update.
* I only tested lmu2png and png2xyz.
* This is cmake only, I have no idea how to update autotools. (Does autotools run on Windows?)
* As Ghabry says, mingw is not tested.
* The manifest files are located in `resources/`. Tell me if you want them somewhere else.