### PR TITLE
KDE XYZ Thumbnailer: Fix incorrect JSON

### DIFF
--- a/xyz-thumbnailer/kde/src/xyz_thumbnail.json
+++ b/xyz-thumbnailer/kde/src/xyz_thumbnail.json
@@ -4,7 +4,7 @@
         "MimeTypes": [
             "image/xyz"
         ],
-        "Name": "RPG Maker 2k/2k3 XYZ Images",
+        "Name": "RPG Maker 2k/2k3 XYZ Images"
     },
     "MimeType": "image/xyz;"
 }


### PR DESCRIPTION
Fixing the JSON makes it possible to disable the Thumbnailer in the Dolphin settings